### PR TITLE
Feature/destination address

### DIFF
--- a/custom_components/ehs_sentinel/__init__.py
+++ b/custom_components/ehs_sentinel/__init__.py
@@ -36,7 +36,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         "polling_yaml": get_entry_option(entry, "polling_yaml", ""),
         "write_mode": get_entry_option(entry, "write_mode", False),
         "extended_logging": get_entry_option(entry, "extended_logging", False),
+        "indoor_address": int(get_entry_option(entry, "indoor_address", 0)),
     }
+    _LOGGER.info(f"Config Dict: {config_dict}")
 
     coordinator = EHSSentinelCoordinator(hass, config_dict, nasa_repo)
     

--- a/custom_components/ehs_sentinel/coordinator.py
+++ b/custom_components/ehs_sentinel/coordinator.py
@@ -76,7 +76,7 @@ class EHSSentinelCoordinator(DataUpdateCoordinator):
             name = "Samsung EHSSentinel",
             manufacturer = "echoDave",
             model = "EHS Sentinel",
-            sw_version = "0.0.4",
+            sw_version = "0.0.6",
         )
     
     def register_entity_adder(self, category, adder):

--- a/custom_components/ehs_sentinel/coordinator.py
+++ b/custom_components/ehs_sentinel/coordinator.py
@@ -38,6 +38,7 @@ class EHSSentinelCoordinator(DataUpdateCoordinator):
         self.polling = config_dict['polling']
         self.extended_logging = config_dict['extended_logging']
         self.polling_yaml = yaml.safe_load(config_dict['polling_yaml'])
+        self.indoor_address = config_dict['indoor_address']
         self.nasa_repo = nasa_repo
         self.processor = MessageProcessor(hass, self)
         self.producer = MessageProducer(hass, self)

--- a/custom_components/ehs_sentinel/manifest.json
+++ b/custom_components/ehs_sentinel/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ehs_sentinel",
   "name": "EHS Sentinel HACS Integration",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "documentation": "https://github.com/echoDaveD/ehs_sentinel_hacs_integration",
   "requirements": ["pyserial", "aiofiles"],
   "codeowners": ["@echoDaveD"],

--- a/custom_components/ehs_sentinel/message_processor.py
+++ b/custom_components/ehs_sentinel/message_processor.py
@@ -59,7 +59,7 @@ class MessageProcessor:
                     value = round(
                         (self.value_store['NASA_EHSSENTINEL_HEAT_OUTPUT'] /
                          self.value_store['NASA_OUTDOOR_CONTROL_WATTMETER_ALL_UNIT']/1000.), 3)
-                    if 0 < value < 20:
+                    if 0 <= value < 20:
                         await self.protocol_message(msg, "NASA_EHSSENTINEL_COP", value)
 
         if msgname in ('NASA_OUTDOOR_CONTROL_WATTMETER_ALL_UNIT_ACCUM', 'LVAR_IN_TOTAL_GENERATED_POWER'):
@@ -68,7 +68,7 @@ class MessageProcessor:
                     value = round(
                         self.value_store['LVAR_IN_TOTAL_GENERATED_POWER'] /
                         self.value_store['NASA_OUTDOOR_CONTROL_WATTMETER_ALL_UNIT_ACCUM'], 3)
-                    if 0 < value < 20:
+                    if 0 <= value < 20:
                         await self.protocol_message(msg, "NASA_EHSSENTINEL_TOTAL_COP", value)
 
     def search_nasa_table(self, address):

--- a/custom_components/ehs_sentinel/message_producer.py
+++ b/custom_components/ehs_sentinel/message_producer.py
@@ -145,7 +145,7 @@ class MessageProducer:
         nasa_msg.set_packet_source_address(255)
         nasa_msg.set_packet_dest_address_class(AddressClassEnum.Indoor)
         nasa_msg.set_packet_dest_channel(0)
-        nasa_msg.set_packet_dest_address(0)
+        nasa_msg.set_packet_dest_address(self.coordinator.indoor_address)
         nasa_msg.set_packet_information(True)
         nasa_msg.set_packet_version(2)
         nasa_msg.set_packet_retry_count(0)

--- a/custom_components/ehs_sentinel/translations/de.json
+++ b/custom_components/ehs_sentinel/translations/de.json
@@ -14,7 +14,8 @@
           "polling_yaml": "Polling-Konfiguration (YAML)",
           "write_mode": "Schreibmodus aktivieren",
           "extended_logging": "Erweitertes Loggin aktivieren (alle Pakete)",
-          "skip_mqtt_test": "Prüfung auf alte MQTT EHS-Sentinel Instanz überspringen (Entitätids doppeln sich und bekommen einen suffix)"
+          "skip_mqtt_test": "Prüfung auf alte MQTT EHS-Sentinel Instanz überspringen (Entitätids doppeln sich und bekommen einen suffix)",
+          "indoor_address": "Indoor Adresse (das letzte Byte)"
         }
       }
     },
@@ -32,7 +33,8 @@
           "polling": "Polling aktivieren",
           "polling_yaml": "Polling-Konfiguration (YAML)",
           "write_mode": "Schreibmodus aktivieren",
-          "extended_logging": "Erweitertes Loggin aktivieren (alle Pakete)"
+          "extended_logging": "Erweitertes Loggin aktivieren (alle Pakete)",
+          "indoor_address": "Indoor Adresse (das letzte Byte)"
         }
       }
     },

--- a/custom_components/ehs_sentinel/translations/en.json
+++ b/custom_components/ehs_sentinel/translations/en.json
@@ -14,7 +14,8 @@
           "polling_yaml": "Polling configuration (YAML)",
           "write_mode": "Write mode enabled",
           "extended_logging": "Enable extended logging (all packets)",
-          "skip_mqtt_test": "Skip check for old MQTT EHS Sentinel instance (Duplicated entity ids will receive a suffix)"
+          "skip_mqtt_test": "Skip check for old MQTT EHS Sentinel instance (Duplicated entity ids will receive a suffix)",
+          "indoor_address": "Indoor Address (the last byte)"
         }
       }
     },
@@ -32,7 +33,8 @@
           "polling": "Polling enabled",
           "polling_yaml": "Polling configuration (YAML)",
           "write_mode": "Write mode enabled",
-          "extended_logging": "Enable extended logging (all packets)"
+          "extended_logging": "Enable extended logging (all packets)",
+          "indoor_address": "Indoor Address (the last byte)"
         }
       }
     },


### PR DESCRIPTION

- add indoor adress as config parm (SOme installations have 200001 instead of 200000 as indoor address) we need only the last byte
- allow 0 value for NASA_EHSSENTINEL_COP and NASA_EHSSENTINEL_TOTAL_COP