### PR TITLE
fix: add missing idle enum values for SERVICEOPERATION, OD_EEV_VALVE, INDOOR_DEFROST_STEP

### DIFF
--- a/custom_components/ehs_sentinel/data/nasa_repository.yml
+++ b/custom_components/ehs_sentinel/data/nasa_repository.yml
@@ -4414,6 +4414,7 @@ NASA_OUTDOOR_INDOOR_DEFROST_STEP:
   address: '0x8061'
   description: Indoor unit defrost operation steps
   enum:
+    0: No defrost
     1: Defrost stage 1
     2: Defrost stage 2
     3: Defrost stage 3
@@ -4424,6 +4425,7 @@ NASA_OUTDOOR_INDOOR_DEFROST_STEP:
     default_platform: sensor
     platform:
       options:
+      - No defrost
       - Defrost stage 1
       - Defrost stage 2
       - Defrost stage 3
@@ -4725,6 +4727,7 @@ NASA_OUTDOOR_OD_EEV_VALVE:
   enum:
     0: 'OFF'
     1: 'ON'
+    255: 'OFF'
   hass_opts:
     default_platform: binary_sensor
     platform:
@@ -5003,6 +5006,7 @@ NASA_OUTDOOR_SERVICEOPERATION:
   enum:
     0: 'OFF'
     1: 'ON'
+    255: 'OFF'
   hass_opts:
     default_platform: binary_sensor
     platform:


### PR DESCRIPTION
On my AE080RXYDEG/EU (Gen 6 R32 monobloc, single outdoor unit) three outdoor messages report a value that isn't in their enum table, so `MessageProcessor` logs `Error determining value for message ...` on every bus cycle and the entities never populate:

| message | address | current enum | value on the bus | this PR adds |
|---|---|---|---|---|
| `NASA_OUTDOOR_SERVICEOPERATION` | 0x8047 | `{0: OFF, 1: ON}` | `255` | `255: OFF` |
| `NASA_OUTDOOR_OD_EEV_VALVE` | 0x8020 | `{0: OFF, 1: ON}` | `255` | `255: OFF` |
| `NASA_OUTDOOR_INDOOR_DEFROST_STEP` | 0x8061 | `{1..4, 7, 255}` | `0` | `0: No defrost` (enum + options list) |

`255` is Samsung's usual N/A sentinel, mapped to `OFF` on both binary_sensors. `0` on the defrost step is "no defrost running", added to both the enum and the select `options` list. Additive only, nothing existing changes.

These were constant over several days of logs on my unit. The active defrost codes (1-4, 7) are already defined; this only adds the idle `0`.

```diff
 NASA_OUTDOOR_INDOOR_DEFROST_STEP:
   enum:
+    0: No defrost
     1: Defrost stage 1
   ...
     platform:
       options:
+      - No defrost
 NASA_OUTDOOR_OD_EEV_VALVE:
   enum:
     0: 'OFF'
     1: 'ON'
+    255: 'OFF'
 NASA_OUTDOOR_SERVICEOPERATION:
   enum:
     0: 'OFF'
     1: 'ON'
+    255: 'OFF'
```
